### PR TITLE
Retrieve table start by "v"

### DIFF
--- a/Util/Tests/ApiTestDataLoaderTrait.php
+++ b/Util/Tests/ApiTestDataLoaderTrait.php
@@ -124,8 +124,7 @@ trait ApiTestDataLoaderTrait
                     FROM information_schema.tables
                     WHERE TABLE_SCHEMA IN ({$schemas})
                     AND TABLE_TYPE = 'BASE TABLE'
-                    AND TABLE_NAME NOT LIKE 'ref_%'
-                    AND TABLE_NAME NOT LIKE 'v_%'
+                    AND TABLE_NAME NOT LIKE 'ref\_%'
                     ";
             $stmt = self::$entityManager->getConnection()->executeQuery($sql);
             $tables = $stmt->fetchAll(\PDO::FETCH_COLUMN);


### PR DESCRIPTION
TABLE_TYPE = 'BASE TABLE' is enough to exclude views. 
The underscore is a joker and must be escaped . "TABLE_NAME like 'ref_%'" match reflection